### PR TITLE
Use `opensource` CircleCI context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ workflows:
   pull_request:
     jobs:
       - test:
+          context: opensource
           filters:
             branches:
               ignore:
@@ -52,6 +53,7 @@ workflows:
   publish:
     jobs:
       - publish:
+          context: opensource
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/


### PR DESCRIPTION
@jdrake @asippel89  

I added a context called `opensource` that has the GitHub and PyPI creds only for now. I'll make PRs to update the config for our existing OS repos.